### PR TITLE
fix: Fix incorrect import path for JoinHandle by importing from std::thread instead of non-existent crate::player::thread

### DIFF
--- a/lok.toml
+++ b/lok.toml
@@ -1,0 +1,21 @@
+[defaults]
+parallel = true
+timeout = 300
+command_wrapper = "nix-shell --run '{cmd}'"
+
+[backends.claude]
+enabled = true
+command = "claude"
+args = []
+
+[backends.codex]
+enabled = true
+command = "codex"
+args = ["exec", "--json", "-s", "read-only"]
+
+[backends.gemini]
+enabled = true
+command = "npx"
+args = ["@google/gemini-cli"]
+skip_lines = 1
+timeout = 600

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -1,11 +1,9 @@
-use crate::player::thread::JoinHandle;
-
 use std::{
     fs::File,
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
     sync::{Arc, Mutex},
-    thread,
+    thread::{self, JoinHandle},
     time::Duration,
 };
 


### PR DESCRIPTION
## Issue
Closes #38: `src/player/mod.rs:1` - Incorrect import `use crate::player::thread::JoinHandle` references a non-existent module (should likely be `std::thread::JoinHandle`). This would cause a compilation error.

## Why this issue?
This is a clear compilation-breaking bug with an obvious one-line fix (change `crate::player::thread::JoinHandle` to `std::thread::JoinHandle`). Highest impact because the code won't compile without this fix, and lowest effort since it's a single import statement change.

## Fix
Fix incorrect import path for JoinHandle by importing from std::thread instead of non-existent crate::player::thread

This fix was developed through Claude + Codex + Gemini consensus.

---
Automated fix by lok pick-and-fix workflow.